### PR TITLE
feat: add interfaces

### DIFF
--- a/data_storage.go
+++ b/data_storage.go
@@ -1,0 +1,78 @@
+package fsm
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// defaultDataStorage is a type for default data storage
+type dataStorage struct {
+	mu      sync.Mutex
+	storage map[int64]map[any]any
+}
+
+// initialDataStorage creates in memory storage for user's data
+func initialDataStorage() *dataStorage {
+	return &dataStorage{
+		storage: make(map[int64]map[any]any),
+	}
+}
+
+// Set sets user's data to data storage
+func (d *dataStorage) Set(userID int64, key, value any) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	s, ok := d.storage[userID]
+	if !ok {
+		s = make(map[any]any)
+		d.storage[userID] = s
+	}
+
+	s[key] = value
+
+	return nil
+}
+
+// Get gets user's data from data storage
+func (d *dataStorage) Get(userID int64, key any) (any, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, ok := d.storage[userID]
+	if !ok {
+		return nil, nil
+	}
+
+	return d.storage[userID][key], nil
+}
+
+// Delete deletes user's data from data storage
+func (d *dataStorage) Delete(userID int64, key any) error {
+	d.mu.Lock()
+	delete(d.storage, userID)
+	d.mu.Unlock()
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler
+func (d *dataStorage) MarshalJSON() ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return json.Marshal(d.storage)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (d *dataStorage) UnmarshalJSON(data []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var response map[int64]map[any]any
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+
+	d.storage = response
+
+	return nil
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package fsm
+
+import "errors"
+
+var (
+	errNoUserData  = errors.New("no user data")
+	errNoUserState = errors.New("no user state")
+)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -70,7 +70,9 @@ func (app *Application) handlerCancel(ctx context.Context, b *bot.Bot, update *m
 	userID := update.Message.From.ID
 	chatID := update.Message.Chat.ID
 
-	if app.f.Current(userID) == stateDefault {
+	currentState, _ := app.f.Current(userID)
+
+	if currentState == stateDefault {
 		return
 	}
 
@@ -86,7 +88,9 @@ func (app *Application) handlerForm(ctx context.Context, b *bot.Bot, update *mod
 	userID := update.Message.From.ID
 	chatID := update.Message.Chat.ID
 
-	if app.f.Current(userID) != stateDefault {
+	currentState, _ := app.f.Current(userID)
+
+	if currentState != stateDefault {
 		return
 	}
 
@@ -101,7 +105,9 @@ func (app *Application) handlerDefault(ctx context.Context, b *bot.Bot, update *
 	userID := update.Message.From.ID
 	chatID := update.Message.Chat.ID
 
-	switch app.f.Current(userID) {
+	currentState, _ := app.f.Current(userID)
+
+	switch currentState {
 	case stateDefault:
 		b.SendMessage(ctx, &bot.SendMessageParams{
 			ChatID: chatID,
@@ -150,7 +156,7 @@ func (app *Application) handlerDefault(ctx context.Context, b *bot.Bot, update *
 		app.f.Transition(userID, stateFinish, chatID, userID)
 
 	default:
-		fmt.Printf("unexpected state %s\n", app.f.Current(userID))
+		fmt.Printf("unexpected state %s\n", currentState)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,0 +1,18 @@
+package fsm
+
+// Option is a type for FSM options
+type Option func(*FSM)
+
+// WithUserStateStorage sets userStateStorage FSM
+func WithUserStateStorage(storage UserStateStorage) Option {
+	return func(fsm *FSM) {
+		fsm.userStates = storage
+	}
+}
+
+// WithDataStorage sets a data storage for FSM
+func WithDataStorage(storage DataStorage) Option {
+	return func(fsm *FSM) {
+		fsm.storage = storage
+	}
+}

--- a/user_state_storage.go
+++ b/user_state_storage.go
@@ -1,0 +1,64 @@
+package fsm
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// userStateStorage is a type for default user's state storage
+type userStateStorage struct {
+	mu      sync.RWMutex
+	storage map[int64]StateID
+}
+
+// initialUserStateStorage creates in memory storage for user's state
+func initialUserStateStorage() *userStateStorage {
+	return &userStateStorage{
+		storage: make(map[int64]StateID),
+	}
+}
+
+// Set sets user's state to state storage
+func (u *userStateStorage) Set(userID int64, stateID StateID) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.storage[userID] = stateID
+	return nil
+}
+
+// Exists checks whether any user's state exist in state storage
+func (u *userStateStorage) Exists(userID int64) (bool, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	_, ok := u.storage[userID]
+	return ok, nil
+}
+
+// Get gets user's state from state storage
+func (u *userStateStorage) Get(userID int64) (StateID, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	s, ok := u.storage[userID]
+	if !ok {
+		return "", nil
+	}
+
+	return s, nil
+}
+
+// MarshalJSON implements json.Marshaler
+func (u *userStateStorage) MarshalJSON() ([]byte, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return json.Marshal(u.storage)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (u *userStateStorage) UnmarshalJSON(data []byte) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return json.Unmarshal(data, &u.storage)
+}


### PR DESCRIPTION
Changed stores type to interfaces and add default implementations for it.
Have question about  marshal/unmarshal methods for structures and they don't work as intended.
Left Set and Get methods to interactions with storage.
What do you think about idea for adding generics to datastore interface? For usefull using instead of any type.